### PR TITLE
Do not attempt to shutdown the audio subsystem if it was never initialised.

### DIFF
--- a/src/sdl_posix/sdl_audio.c
+++ b/src/sdl_posix/sdl_audio.c
@@ -152,6 +152,9 @@ void Audio_ChannelPlay() {
 void Audio_Start() {}
 
 void Audio_Close() {
+  if (!audio_open)
+    return;
+
   if (Mix_Playing(streamChannel)) {
     Mix_FadeOutChannel(streamChannel, 200);
   }


### PR DESCRIPTION
Fix panic when the posix target is executed without enabling audio.